### PR TITLE
chore: Small refactor to separate preset transforms

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -1,17 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const esModules = [
-  '@cloudscape-design',
+const esModules = ['d3-.*', 'internmap'].join('|');
 
-  // `d3-color` and `d3-scale` packages (plus their transitive dependencies) are using the ESM format.
-  // We need to transform them to have them working in tests.
-  'd3-.*',
-  'internmap',
-].join('|');
 module.exports = {
   transform: {
-    [`node_modules/(${esModules})/.+\\.js$`]: require.resolve('./js-transformer'),
+    'node_modules/@cloudscape-design/.+\\.js$': require.resolve('./js-transformer'),
     'node_modules/@cloudscape-design/.+\\.css': require.resolve('./css-transformer'),
+
+    // `d3-color` and `d3-scale` packages (plus their transitive dependencies) are using the ESM format.
+    // We need to transform them to have them working in tests.
+    [`node_modules/(${esModules})/.+\\.js$`]: require.resolve('./js-transformer'),
   },
-  transformIgnorePatterns: [`/node_modules/(?!(${esModules})/).+\\.js$`],
+  transformIgnorePatterns: [`/node_modules/(?!(${esModules}|@cloudscape-design/)).+\\.js$`],
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Separate third party lib transforms from cloudscape to provide clearer separation when doing internal processing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
