### PR TITLE
chore: Upgrade tap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "husky": "^7.0.0",
         "lint-staged": "^11.1.1",
         "prettier": "^2.3.2",
-        "tap": "^16.0.1"
+        "tap": "^16.3.3"
       },
       "peerDependencies": {
         "babel-jest": ">=24",
@@ -1875,8 +1875,9 @@
     },
     "node_modules/async-hook-domain": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-2.0.4.tgz",
+      "integrity": "sha512-14LjCmlK1PK8eDtTezR6WX8TMaYNIzBIsd2D1sGoGjgx0BuNMMoSdk7i/drlbtamy0AWv9yv2tkB+ASdmeqFIw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -2088,8 +2089,9 @@
     },
     "node_modules/bind-obj-methods": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-3.0.0.tgz",
+      "integrity": "sha512-nLEaaz3/sEzNSyPWRsN9HNsqwk1AUyECtGj+XwGdIi3xABnEqecvXtIJ0wehQXuuER5uZ/5fTs2usONgYjG+iw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -2353,8 +2355,9 @@
     },
     "node_modules/cliui": {
       "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -3189,8 +3192,9 @@
     },
     "node_modules/function-loop": {
       "version": "2.0.1",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-2.0.1.tgz",
+      "integrity": "sha512-ktIR+O6i/4h+j/ZhZJNdzeI4i9lEPeEK6UPR2EVyTVBqOwcU3Za9xYKLH64ZR9HmcROyRrOkizNyjjtWJzDDkQ==",
+      "dev": true
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -3254,13 +3258,14 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "license": "ISC",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -3601,17 +3606,17 @@
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=8"
@@ -3688,9 +3693,10 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "1.4.1",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-1.4.2.tgz",
+      "integrity": "sha512-GHeGTmnuaHnvS+ZctRB01bfxARuu9wW83ENbuiweu07SFcVlZrJpcshSre/keGT7YGBhLHg/+rXCNSrsEHKU4Q==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "cliui": "^7.0.4"
       },
@@ -5458,9 +5464,10 @@
       }
     },
     "node_modules/libtap": {
-      "version": "1.3.0",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/libtap/-/libtap-1.4.0.tgz",
+      "integrity": "sha512-STLFynswQ2A6W14JkabgGetBNk6INL1REgJ9UeNKw5llXroC2cGLgKTqavv0sl8OLVztLLipVKMcQ7yeUcqpmg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "async-hook-domain": "^2.0.4",
         "bind-obj-methods": "^3.0.0",
@@ -5765,9 +5772,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "3.1.6",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5979,13 +5987,15 @@
     },
     "node_modules/own-or": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
+      "integrity": "sha512-NfZr5+Tdf6MB8UI9GLvKRs4cXY8/yB0w3xtt84xFdWy8hkGjn+JFc60VhzS/hFRfbyxFcGYMTjnF4Me+RbbqrA==",
+      "dev": true
     },
     "node_modules/own-or-env": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.2.tgz",
+      "integrity": "sha512-NQ7v0fliWtK7Lkb+WdFqe6ky9XAzYmlkXthQrBbzlYbmFKoAYbDDcwmOm6q8kOuwSRXW8bdL5ORksploUJmWgw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "own-or": "^1.0.0"
       }
@@ -6760,7 +6770,9 @@
       "license": "MIT"
     },
     "node_modules/tap": {
-      "version": "16.0.1",
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.3.tgz",
+      "integrity": "sha512-E6Ti4FaH3zUvOtl13GA60n8aodRj44S8Vu5efM84U5NmquJo4+y21+2VM9r9jR5iiEcce5dqvlrrwAhZ6r11xg==",
       "bundleDependencies": [
         "ink",
         "treport",
@@ -6769,21 +6781,20 @@
         "react"
       ],
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@isaacs/import-jsx": "^4.0.1",
-        "@types/react": "^17",
+        "@types/react": "^17.0.52",
         "chokidar": "^3.3.0",
         "findit": "^2.0.0",
         "foreground-child": "^2.0.0",
         "fs-exists-cached": "^1.0.0",
-        "glob": "^7.1.6",
+        "glob": "^7.2.3",
         "ink": "^3.2.0",
         "isexe": "^2.0.0",
-        "istanbul-lib-processinfo": "^2.0.2",
-        "jackspeak": "^1.4.1",
-        "libtap": "^1.3.0",
-        "minipass": "^3.1.1",
+        "istanbul-lib-processinfo": "^2.0.3",
+        "jackspeak": "^1.4.2",
+        "libtap": "^1.4.0",
+        "minipass": "^3.3.4",
         "mkdirp": "^1.0.4",
         "nyc": "^15.1.0",
         "opener": "^1.5.1",
@@ -6792,10 +6803,10 @@
         "signal-exit": "^3.0.6",
         "source-map-support": "^0.5.16",
         "tap-mocha-reporter": "^5.0.3",
-        "tap-parser": "^11.0.1",
-        "tap-yaml": "^1.0.0",
+        "tap-parser": "^11.0.2",
+        "tap-yaml": "^1.0.2",
         "tcompare": "^5.0.7",
-        "treport": "^3.0.3",
+        "treport": "^3.0.4",
         "which": "^2.0.2"
       },
       "bin": {
@@ -6858,9 +6869,10 @@
       }
     },
     "node_modules/tap-parser": {
-      "version": "11.0.1",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-11.0.2.tgz",
+      "integrity": "sha512-6qGlC956rcORw+fg7Fv1iCRAY8/bU9UabUAhs3mXRH6eRmVZcNPLheSXCYaVaYeSwx5xa/1HXZb1537YSvwDZg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "events-to-array": "^1.0.1",
         "minipass": "^3.1.6",
@@ -6874,11 +6886,12 @@
       }
     },
     "node_modules/tap-yaml": {
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.2.tgz",
+      "integrity": "sha512-GegASpuqBnRNdT1U+yuUPZ8rEU64pL35WPBpCISWwff4dErS2/438barz7WFJl4Nzh3Y05tfPidZnH+GaV1wMg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "yaml": "^1.5.0"
+        "yaml": "^1.10.2"
       }
     },
     "node_modules/tap/node_modules/@ampproject/remapping": {
@@ -7355,7 +7368,7 @@
       "license": "MIT"
     },
     "node_modules/tap/node_modules/@types/react": {
-      "version": "17.0.41",
+      "version": "17.0.52",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7794,7 +7807,7 @@
       }
     },
     "node_modules/tap/node_modules/glob": {
-      "version": "7.2.0",
+      "version": "7.2.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7802,7 +7815,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -8009,7 +8022,7 @@
       }
     },
     "node_modules/tap/node_modules/json5": {
-      "version": "2.2.1",
+      "version": "2.2.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8087,7 +8100,7 @@
       }
     },
     "node_modules/tap/node_modules/minipass": {
-      "version": "3.1.6",
+      "version": "3.3.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8472,7 +8485,7 @@
       }
     },
     "node_modules/tap/node_modules/tap-parser": {
-      "version": "11.0.1",
+      "version": "11.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8489,12 +8502,12 @@
       }
     },
     "node_modules/tap/node_modules/tap-yaml": {
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "yaml": "^1.5.0"
+        "yaml": "^1.10.2"
       }
     },
     "node_modules/tap/node_modules/to-fast-properties": {
@@ -8507,7 +8520,7 @@
       }
     },
     "node_modules/tap/node_modules/treport": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8518,6 +8531,7 @@
         "ink": "^3.2.0",
         "ms": "^2.1.2",
         "tap-parser": "^11.0.0",
+        "tap-yaml": "^1.0.0",
         "unicode-length": "^2.0.2"
       },
       "peerDependencies": {
@@ -8749,8 +8763,9 @@
     },
     "node_modules/tcompare": {
       "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-5.0.7.tgz",
+      "integrity": "sha512-d9iddt6YYGgyxJw5bjsN7UJUO1kGOtjSlNy/4PoGYAjQS5pAT/hzIoLf1bZCw+uUxRmZJh7Yy1aA7xKVRT9B4w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "diff": "^4.0.2"
       },
@@ -8805,8 +8820,9 @@
     },
     "node_modules/trivial-deferred": {
       "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
+      "integrity": "sha512-dagAKX7vaesNNAwOc9Np9C2mJ+7YopF4lk+jE2JML9ta4kZ91Y6UruJNH65bLRYoUROD8EY+Pmi44qQWwXR7sw==",
+      "dev": true
     },
     "node_modules/tslib": {
       "version": "2.1.0",
@@ -8889,11 +8905,12 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -10456,6 +10473,8 @@
     },
     "async-hook-domain": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-2.0.4.tgz",
+      "integrity": "sha512-14LjCmlK1PK8eDtTezR6WX8TMaYNIzBIsd2D1sGoGjgx0BuNMMoSdk7i/drlbtamy0AWv9yv2tkB+ASdmeqFIw==",
       "dev": true
     },
     "babel-jest": {
@@ -10615,6 +10634,8 @@
     },
     "bind-obj-methods": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-3.0.0.tgz",
+      "integrity": "sha512-nLEaaz3/sEzNSyPWRsN9HNsqwk1AUyECtGj+XwGdIi3xABnEqecvXtIJ0wehQXuuER5uZ/5fTs2usONgYjG+iw==",
       "dev": true
     },
     "brace-expansion": {
@@ -10773,6 +10794,8 @@
     },
     "cliui": {
       "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.0",
@@ -11312,6 +11335,8 @@
     },
     "function-loop": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-2.0.1.tgz",
+      "integrity": "sha512-ktIR+O6i/4h+j/ZhZJNdzeI4i9lEPeEK6UPR2EVyTVBqOwcU3Za9xYKLH64ZR9HmcROyRrOkizNyjjtWJzDDkQ==",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -11347,12 +11372,14 @@
       "version": "6.0.1"
     },
     "glob": {
-      "version": "7.2.0",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -11541,16 +11568,17 @@
       }
     },
     "istanbul-lib-processinfo": {
-      "version": "2.0.2",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       },
       "dependencies": {
         "p-map": {
@@ -11602,7 +11630,9 @@
       }
     },
     "jackspeak": {
-      "version": "1.4.1",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-1.4.2.tgz",
+      "integrity": "sha512-GHeGTmnuaHnvS+ZctRB01bfxARuu9wW83ENbuiweu07SFcVlZrJpcshSre/keGT7YGBhLHg/+rXCNSrsEHKU4Q==",
       "dev": true,
       "requires": {
         "cliui": "^7.0.4"
@@ -12900,7 +12930,9 @@
       }
     },
     "libtap": {
-      "version": "1.3.0",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/libtap/-/libtap-1.4.0.tgz",
+      "integrity": "sha512-STLFynswQ2A6W14JkabgGetBNk6INL1REgJ9UeNKw5llXroC2cGLgKTqavv0sl8OLVztLLipVKMcQ7yeUcqpmg==",
       "dev": true,
       "requires": {
         "async-hook-domain": "^2.0.4",
@@ -13111,7 +13143,9 @@
       }
     },
     "minipass": {
-      "version": "3.1.6",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -13256,10 +13290,14 @@
     },
     "own-or": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
+      "integrity": "sha512-NfZr5+Tdf6MB8UI9GLvKRs4cXY8/yB0w3xtt84xFdWy8hkGjn+JFc60VhzS/hFRfbyxFcGYMTjnF4Me+RbbqrA==",
       "dev": true
     },
     "own-or-env": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.2.tgz",
+      "integrity": "sha512-NQ7v0fliWtK7Lkb+WdFqe6ky9XAzYmlkXthQrBbzlYbmFKoAYbDDcwmOm6q8kOuwSRXW8bdL5ORksploUJmWgw==",
       "dev": true,
       "requires": {
         "own-or": "^1.0.0"
@@ -13758,22 +13796,24 @@
       }
     },
     "tap": {
-      "version": "16.0.1",
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.3.tgz",
+      "integrity": "sha512-E6Ti4FaH3zUvOtl13GA60n8aodRj44S8Vu5efM84U5NmquJo4+y21+2VM9r9jR5iiEcce5dqvlrrwAhZ6r11xg==",
       "dev": true,
       "requires": {
         "@isaacs/import-jsx": "^4.0.1",
-        "@types/react": "^17",
+        "@types/react": "^17.0.52",
         "chokidar": "^3.3.0",
         "findit": "^2.0.0",
         "foreground-child": "^2.0.0",
         "fs-exists-cached": "^1.0.0",
-        "glob": "^7.1.6",
+        "glob": "^7.2.3",
         "ink": "^3.2.0",
         "isexe": "^2.0.0",
-        "istanbul-lib-processinfo": "^2.0.2",
-        "jackspeak": "^1.4.1",
-        "libtap": "^1.3.0",
-        "minipass": "^3.1.1",
+        "istanbul-lib-processinfo": "^2.0.3",
+        "jackspeak": "^1.4.2",
+        "libtap": "^1.4.0",
+        "minipass": "^3.3.4",
         "mkdirp": "^1.0.4",
         "nyc": "^15.1.0",
         "opener": "^1.5.1",
@@ -13782,10 +13822,10 @@
         "signal-exit": "^3.0.6",
         "source-map-support": "^0.5.16",
         "tap-mocha-reporter": "^5.0.3",
-        "tap-parser": "^11.0.1",
-        "tap-yaml": "^1.0.0",
+        "tap-parser": "^11.0.2",
+        "tap-yaml": "^1.0.2",
         "tcompare": "^5.0.7",
-        "treport": "^3.0.3",
+        "treport": "^3.0.4",
         "which": "^2.0.2"
       },
       "dependencies": {
@@ -14107,7 +14147,7 @@
           "dev": true
         },
         "@types/react": {
-          "version": "17.0.41",
+          "version": "17.0.52",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14384,14 +14424,14 @@
           "dev": true
         },
         "glob": {
-          "version": "7.2.0",
+          "version": "7.2.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -14524,7 +14564,7 @@
           "dev": true
         },
         "json5": {
-          "version": "2.2.1",
+          "version": "2.2.3",
           "bundled": true,
           "dev": true
         },
@@ -14571,7 +14611,7 @@
           }
         },
         "minipass": {
-          "version": "3.1.6",
+          "version": "3.3.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14830,7 +14870,7 @@
           }
         },
         "tap-parser": {
-          "version": "11.0.1",
+          "version": "11.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14840,11 +14880,11 @@
           }
         },
         "tap-yaml": {
-          "version": "1.0.0",
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "yaml": "^1.5.0"
+            "yaml": "^1.10.2"
           }
         },
         "to-fast-properties": {
@@ -14853,7 +14893,7 @@
           "dev": true
         },
         "treport": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14863,6 +14903,7 @@
             "ink": "^3.2.0",
             "ms": "^2.1.2",
             "tap-parser": "^11.0.0",
+            "tap-yaml": "^1.0.0",
             "unicode-length": "^2.0.2"
           },
           "dependencies": {
@@ -15033,7 +15074,9 @@
       }
     },
     "tap-parser": {
-      "version": "11.0.1",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-11.0.2.tgz",
+      "integrity": "sha512-6qGlC956rcORw+fg7Fv1iCRAY8/bU9UabUAhs3mXRH6eRmVZcNPLheSXCYaVaYeSwx5xa/1HXZb1537YSvwDZg==",
       "dev": true,
       "requires": {
         "events-to-array": "^1.0.1",
@@ -15042,14 +15085,18 @@
       }
     },
     "tap-yaml": {
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.2.tgz",
+      "integrity": "sha512-GegASpuqBnRNdT1U+yuUPZ8rEU64pL35WPBpCISWwff4dErS2/438barz7WFJl4Nzh3Y05tfPidZnH+GaV1wMg==",
       "dev": true,
       "requires": {
-        "yaml": "^1.5.0"
+        "yaml": "^1.10.2"
       }
     },
     "tcompare": {
       "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-5.0.7.tgz",
+      "integrity": "sha512-d9iddt6YYGgyxJw5bjsN7UJUO1kGOtjSlNy/4PoGYAjQS5pAT/hzIoLf1bZCw+uUxRmZJh7Yy1aA7xKVRT9B4w==",
       "dev": true,
       "requires": {
         "diff": "^4.0.2"
@@ -15088,6 +15135,8 @@
     },
     "trivial-deferred": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
+      "integrity": "sha512-dagAKX7vaesNNAwOc9Np9C2mJ+7YopF4lk+jE2JML9ta4kZ91Y6UruJNH65bLRYoUROD8EY+Pmi44qQWwXR7sw==",
       "dev": true
     },
     "tslib": {
@@ -15147,7 +15196,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
     "v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "prepare": "husky install"
   },
   "peerDependencies": {
-    "jest": ">=24",
-    "babel-jest": ">=24"
+    "babel-jest": ">=24",
+    "jest": ">=24"
   },
   "dependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.9.0"
@@ -32,7 +32,7 @@
     "husky": "^7.0.0",
     "lint-staged": "^11.1.1",
     "prettier": "^2.3.2",
-    "tap": "^16.0.1"
+    "tap": "^16.3.3"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
*Description of changes:*
This upgrades `tap`, which in turn updates `glob`. This should fix the dependabot alert: https://github.com/cloudscape-design/jest-preset/security/dependabot/2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
