### PR TITLE
fix: Ignore project configuration files

### DIFF
--- a/js-transformer.js
+++ b/js-transformer.js
@@ -7,4 +7,7 @@ const babelJest = babelJestModule.__esModule ? babelJestModule.default : babelJe
 
 module.exports = babelJest.createTransformer({
   plugins: [require.resolve('@babel/plugin-transform-modules-commonjs')],
+  // do not load own project configuration files
+  babelrc: false,
+  configFile: false,
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Disable default babel behavior where it reads and applies configuration from `.babelrc` and `babel.config.js` files, because they may break our code

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
