### PR TITLE
chore: switch to @tony.ganchev/eslint-plugin-header

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,14 +6,14 @@
   "env": {
     "node": true
   },
-  "plugins": ["unicorn", "header"],
+  "plugins": ["unicorn", "@tony.ganchev/header"],
   "rules": {
     "unicorn/filename-case": "error",
     "curly": "error",
     "eqeqeq": "error",
     "no-return-await": "error",
     "require-await": "error",
-    "header/header": [
+    "@tony.ganchev/header/header": [
       "error",
       "line",
       [" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.", " SPDX-License-Identifier: Apache-2.0"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "lodash": "^4.18.1"
       },
       "devDependencies": {
+        "@tony.ganchev/eslint-plugin-header": "^3.3.1",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-header": "3.1.1",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-unicorn": "^50.0.1",
         "husky": "^9.0.10",
@@ -1462,6 +1462,16 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tony.ganchev/eslint-plugin-header": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@tony.ganchev/eslint-plugin-header/-/eslint-plugin-header-3.3.1.tgz",
+      "integrity": "sha512-/Fj0+DaXbBfrlXmd3wBZkB8TIwGT3N++y/oTYxRABK/gzNxjgcBjt63xBpuHCYIXmH1EwuALd6XS1fzNG4S0zg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7.7.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2470,15 +2480,6 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-header": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
-      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true,
-      "peerDependencies": {
-        "eslint": ">=7.7.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "lodash": "^4.18.1"
   },
   "devDependencies": {
+    "@tony.ganchev/eslint-plugin-header": "^3.3.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-header": "3.1.1",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unicorn": "^50.0.1",
     "husky": "^9.0.10",


### PR DESCRIPTION
Hi, team,

I noticed you are using _eslint-plugin-header_ on ESLint 8.

I forked _@tony.ganchev/eslint-plugin-header_ mid-2024 to add support for
ESLint 9 and hoped it would be a temporary measure but since the
original has not been updated for five years I decided to continue
improving the new plugin and have been doing so for the last two years.

Specific improvements include:
- full JSON schema for validating the configuration.
- fixed multiple bugs with the behavior of the plugin on Windows.
- many other bug-fixes.
- improved autofixing and error-reporting behavior.
- added support for leading pragma comments before the header such as
  `@jest-environment`.

I've sent PR proposals to other projects in the _cloudscape-design_ space:
- https://github.com/cloudscape-design/board-components/pull/401
- https://github.com/cloudscape-design/browser-test-tools/pull/188
- https://github.com/cloudscape-design/build-tools/pull/38
- https://github.com/cloudscape-design/chart-components/pull/185
- https://github.com/cloudscape-design/chat-components/pull/121
- https://github.com/cloudscape-design/code-view/pull/122
- https://github.com/cloudscape-design/collection-hooks/pull/136
- https://github.com/cloudscape-design/component-toolkit/pull/200
- https://github.com/cloudscape-design/components/pull/4308
- https://github.com/cloudscape-design/demos/pull/243
- https://github.com/cloudscape-design/documenter/pull/112
- https://github.com/cloudscape-design/global-styles/pull/73
- https://github.com/cloudscape-design/test-utils/pull/114
- https://github.com/cloudscape-design/theming-core/pull/148

Looking forward to your feedback.